### PR TITLE
Update AZ-204_lab_09.md

### DIFF
--- a/Instructions/Labs/AZ-204_lab_09.md
+++ b/Instructions/Labs/AZ-204_lab_09.md
@@ -68,27 +68,27 @@ Find the taskbar on your Windows 10 desktop. The taskbar contains the icons for 
 
     a. Run the following command to get a list of subgroups and commands at the root level of the Azure CLI:
 
-        ```bash
-        az --help
-        ```
+    ```bash
+    az --help
+    ```
 
     b. Run the following command to get a list of the commands that are available for resource providers:
 
-        ```bash
-        az provider --help
-        ```
+    ```bash
+    az provider --help
+    ```
 
     c. Run the following command to list all currently registered providers:
 
-        ```bash
-        az provider list
-        ```
+    ```bash
+    az provider list
+    ```
 
     d. Run the following command to list just the namespaces of the currently registered providers:
 
-        ```bash
-        az provider list --query "[].namespace"
-        ```
+    ```bash
+    az provider list --query "[].namespace"
+    ```
 
     e. Review the list of currently registered providers. Notice that the **Microsoft.EventGrid** provider is currently included in the list of providers.
 
@@ -359,69 +359,73 @@ In this exercise, you created a new subscription, validated its registration, an
 
     a. Add the following line of code to create a new variable named **endpoint** of type **Uri**, using the **topicEndpoint** string constant as a constructor parameter:
 
-        ```csharp
-        Uri endpoint = new Uri(topicEndpoint); 
-        ```
+    ```csharp
+    Uri endpoint = new Uri(topicEndpoint); 
+    ```
 
     b. Add the following line of code to create a new variable named **credential** of type **[AzureKeyCredential](https://docs.microsoft.com/dotnet/api/azure.azurekeycredential)**, using the **topicKey** string constant as a constructor parameter:
 
-        ```csharp
-        AzureKeyCredential credential = new AzureKeyCredential(topicKey);
-        ```
+    ```csharp
+    AzureKeyCredential credential = new AzureKeyCredential(topicKey);
+    ```
 
     c. Add the following line of code to create a new variable named **client** of type **[EventGridPublisherClient](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient)**, using the **endpoint** and **credential** variables as constructor parameters:
 
-        ```csharp
-        EventGridPublisherClient client = new EventGridPublisherClient(endpoint, credential);
-        ```
+    ```csharp
+    EventGridPublisherClient client = new EventGridPublisherClient(endpoint, credential);
+    ```
 
     d. Add the following block of code to create a new variable named **firstEvent** of type **[EventGridEvent](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridevent)** and populate that variable with sample data:
 
-        ```csharp
-        EventGridEvent firstEvent = new EventGridEvent(
-            subject: $"New Employee: Alba Sutton",
-            eventType: "Employees.Registration.New",
-            dataVersion: "1.0",
-            data: new
-            {
-                FullName = "Alba Sutton",
-                Address = "4567 Pine Avenue, Edison, WA 97202"
-            }
-        );
-        ```
+    ```csharp
+    EventGridEvent firstEvent = new EventGridEvent(
+        subject: $"New Employee: Alba Sutton",
+        eventType: "Employees.Registration.New",
+        dataVersion: "1.0",
+        data: new
+        {
+            FullName = "Alba Sutton",
+            Address = "4567 Pine Avenue, Edison, WA 97202"
+        }
+    );
+    ```
 
     e. Add the following block of code to create a new variable named **secondEvent** of type **[EventGridEvent](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridevent)** and populate that variable with sample data:
-
-        ```csharp
-        EventGridEvent secondEvent = new EventGridEvent(
-            subject: $"New Employee: Alexandre Doyon",
-            eventType: "Employees.Registration.New",
-            dataVersion: "1.0",
-            data: new
-            {
-                FullName = "Alexandre Doyon",
-                Address = "456 College Street, Bow, WA 98107"
-            }
-        );
-        ```
+    
+    ```csharp
+    EventGridEvent secondEvent = new EventGridEvent(
+        subject: $"New Employee: Alexandre Doyon",
+        eventType: "Employees.Registration.New",
+        dataVersion: "1.0",
+        data: new
+        {
+            FullName = "Alexandre Doyon",
+            Address = "456 College Street, Bow, WA 98107"
+        }
+    );
+    ```
 
     f. Add the following line of code to asynchronously invoke the **[EventGridPublisherClient.SendEventAsync](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient.sendeventasync)** method using the **firstEvent** variable as a parameter:
 
-        ```csharp
-        await client.SendEventAsync(firstEvent);
-        ```
+    ```csharp
+    await client.SendEventAsync(firstEvent);
+    ```
+
 
     g. Add the following line of code to render the **"First event published"** message to the console:
 
-        ```csharp
-        Console.WriteLine("First event published");
-        ```
+    ```csharp
+    Console.WriteLine("First event published");
+    ```
+
 
     h. Add the following line of code to asynchronously invoke the **[EventGridPublisherClient.SendEventAsync](https://docs.microsoft.com/dotnet/api/azure.messaging.eventgrid.eventgridpublisherclient.sendeventasync)** method using the **secondEvent** variable as a parameter:
 
-        ```csharp
-        await client.SendEventAsync(secondEvent);
-        ```
+
+    ```csharp
+    Console.WriteLine("Second event published");
+    ```
+
 
     i. Add the following line of code to render the **"Second event published"** message to the console:
 


### PR DESCRIPTION
Small correction to indention of the code blocks.  Since this uses a, b, c, d etc. the code label is improperly displaying with the tripple `.  You can format it the way you had, but you want to put 1. instead.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-